### PR TITLE
docs: add drawio doc

### DIFF
--- a/docs/pyaudio.drawio
+++ b/docs/pyaudio.drawio
@@ -1,0 +1,43 @@
+<mxfile host="65bd71144e">
+    <diagram name="Page-1" id="5JtmjxZ7_MOpq23QLKK0">
+        <mxGraphModel dx="1676" dy="745" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="0" pageScale="1" pageWidth="850" pageHeight="1100" math="0" shadow="0">
+            <root>
+                <mxCell id="0"/>
+                <mxCell id="1" parent="0"/>
+                <mxCell id="zTDAnFvsAF5PBpJ9swVf-1" value="cli" style="rounded=0;whiteSpace=wrap;html=1;" parent="1" vertex="1">
+                    <mxGeometry x="-60" y="260" width="120" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="zTDAnFvsAF5PBpJ9swVf-2" value="InputHandler" style="rounded=0;whiteSpace=wrap;html=1;" parent="1" vertex="1">
+                    <mxGeometry x="210" y="260" width="120" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="zTDAnFvsAF5PBpJ9swVf-3" value="" style="endArrow=classic;html=1;rounded=0;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" parent="1" source="zTDAnFvsAF5PBpJ9swVf-1" target="zTDAnFvsAF5PBpJ9swVf-2" edge="1">
+                    <mxGeometry width="50" height="50" relative="1" as="geometry">
+                        <mxPoint x="400" y="400" as="sourcePoint"/>
+                        <mxPoint x="450" y="350" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="zTDAnFvsAF5PBpJ9swVf-4" value="ユーザーからの入力 (URL、Cなど) を受け取ってユースケースに渡す" style="text;html=1;align=left;verticalAlign=middle;whiteSpace=wrap;rounded=0;" parent="1" vertex="1">
+                    <mxGeometry x="210" y="320" width="190" height="40" as="geometry"/>
+                </mxCell>
+                <mxCell id="zTDAnFvsAF5PBpJ9swVf-6" value="" style="endArrow=classic;html=1;rounded=0;exitX=1;exitY=0.5;exitDx=0;exitDy=0;" parent="1" source="zTDAnFvsAF5PBpJ9swVf-2" target="zTDAnFvsAF5PBpJ9swVf-8" edge="1">
+                    <mxGeometry width="50" height="50" relative="1" as="geometry">
+                        <mxPoint x="330" y="289.5" as="sourcePoint"/>
+                        <mxPoint x="480" y="289.5" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="zTDAnFvsAF5PBpJ9swVf-8" value="DownloadAudioUseCase" style="rounded=0;whiteSpace=wrap;html=1;" parent="1" vertex="1">
+                    <mxGeometry x="480" y="260" width="150" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="zTDAnFvsAF5PBpJ9swVf-9" value="" style="endArrow=classic;html=1;rounded=0;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" parent="1" source="zTDAnFvsAF5PBpJ9swVf-2" target="zTDAnFvsAF5PBpJ9swVf-10" edge="1">
+                    <mxGeometry width="50" height="50" relative="1" as="geometry">
+                        <mxPoint x="340" y="300" as="sourcePoint"/>
+                        <mxPoint x="480" y="400" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="zTDAnFvsAF5PBpJ9swVf-10" value="FinishDownloadUseCase" style="rounded=0;whiteSpace=wrap;html=1;" parent="1" vertex="1">
+                    <mxGeometry x="480" y="370" width="150" height="60" as="geometry"/>
+                </mxCell>
+            </root>
+        </mxGraphModel>
+    </diagram>
+</mxfile>


### PR DESCRIPTION
This pull request introduces a new diagram to the `docs/pyaudio.drawio` file, which visually represents the interaction between various components in the system.

* Added a new diagram in `docs/pyaudio.drawio` to illustrate the flow between the `cli`, `InputHandler`, `DownloadAudioUseCase`, and `FinishDownloadUseCase` components.