### PR TITLE
refactor: Modify namings

### DIFF
--- a/docs/pyaudio.drawio
+++ b/docs/pyaudio.drawio
@@ -52,7 +52,7 @@
                         <mxPoint x="1030" y="400" as="targetPoint"/>
                     </mxGeometry>
                 </mxCell>
-                <mxCell id="8" value="AudioFileWriter" style="rounded=0;whiteSpace=wrap;html=1;" parent="1" vertex="1">
+                <mxCell id="8" value="BinaryWriter" style="rounded=0;whiteSpace=wrap;html=1;" parent="1" vertex="1">
                     <mxGeometry x="1050" y="440" width="120" height="60" as="geometry"/>
                 </mxCell>
                 <mxCell id="9" value="" style="endArrow=classic;html=1;rounded=0;" parent="1" source="10" target="8" edge="1">
@@ -61,7 +61,7 @@
                         <mxPoint x="1170" y="470" as="targetPoint"/>
                     </mxGeometry>
                 </mxCell>
-                <mxCell id="10" value="EnglishAudioFileWriter" style="rounded=0;whiteSpace=wrap;html=1;" parent="1" vertex="1">
+                <mxCell id="10" value="AudioFileWriter" style="rounded=0;whiteSpace=wrap;html=1;" parent="1" vertex="1">
                     <mxGeometry x="1320" y="440" width="150" height="60" as="geometry"/>
                 </mxCell>
                 <mxCell id="13" value="ダウンロードメッセージの生成" style="text;html=1;align=left;verticalAlign=middle;whiteSpace=wrap;rounded=0;" parent="1" vertex="1">

--- a/main.py
+++ b/main.py
@@ -1,8 +1,8 @@
 import logging
 
 from src.application.use_cases import DownloadAudioUseCase
-from src.infrastructure.file import EnglishAudioFileWriter
-from src.infrastructure.repositories import EnglishAudioRepository
+from src.infrastructure.file import AudioFileWriter
+from src.infrastructure.repositories import GeneralAudioRepository
 from src.presentation.cli import CommandHandler
 from src.utils import setup_argparse, setup_logger
 
@@ -15,8 +15,8 @@ def main() -> None:
 
     command_handler = CommandHandler(
         download_audio_use_case=DownloadAudioUseCase(
-            audio_file_writer=EnglishAudioFileWriter(),
-            audio_repository=EnglishAudioRepository(),
+            binary_writer=AudioFileWriter(),
+            audio_repository=GeneralAudioRepository(),
         )
     )
 

--- a/src/application/interfaces/__init__.py
+++ b/src/application/interfaces/__init__.py
@@ -1,4 +1,4 @@
-from .audio_file_writer import AudioFileWriter
 from .audio_repository import AudioRepository
+from .binary_writer import BinaryWriter
 
-__all__ = ['AudioRepository', 'AudioFileWriter']
+__all__ = ['AudioRepository', 'BinaryWriter']

--- a/src/application/interfaces/binary_writer.py
+++ b/src/application/interfaces/binary_writer.py
@@ -3,7 +3,7 @@ from abc import ABC, abstractmethod
 import requests
 
 
-class AudioFileWriter(ABC):
+class BinaryWriter(ABC):
     @abstractmethod
     def write(self, stream: requests.Response, file_path: str) -> None:
         pass

--- a/src/application/use_cases/download_audio_use_case.py
+++ b/src/application/use_cases/download_audio_use_case.py
@@ -1,6 +1,6 @@
 import requests
 
-from src.application.interfaces import AudioFileWriter, AudioRepository
+from src.application.interfaces import AudioRepository, BinaryWriter
 from src.exceptions import FetchAudioStreamError, WriteAudioFileError
 
 
@@ -8,10 +8,10 @@ class DownloadAudioUseCase:
     def __init__(
         self,
         audio_repository: AudioRepository,
-        audio_file_writer: AudioFileWriter,
+        binary_writer: BinaryWriter,
     ) -> None:
         self.audio_repository = audio_repository
-        self.audio_file_writer = audio_file_writer
+        self.binary_writer = binary_writer
 
     def execute(self, url: str, file_path: str) -> None:
         try:
@@ -29,4 +29,4 @@ class DownloadAudioUseCase:
     def _write_audio_file(
         self, stream: requests.Response, file_path: str
     ) -> None:
-        self.audio_file_writer.write(stream, file_path)
+        self.binary_writer.write(stream, file_path)

--- a/src/infrastructure/file/__init__.py
+++ b/src/infrastructure/file/__init__.py
@@ -1,3 +1,3 @@
-from .english_audio_file_writer import EnglishAudioFileWriter
+from .audio_file_writer import AudioFileWriter
 
-__all__ = ['EnglishAudioFileWriter']
+__all__ = ['AudioFileWriter']

--- a/src/infrastructure/file/audio_file_writer.py
+++ b/src/infrastructure/file/audio_file_writer.py
@@ -1,10 +1,10 @@
 import requests
 
-from src.application.interfaces import AudioFileWriter
+from src.application.interfaces import BinaryWriter
 from src.exceptions import FetchAudioStreamError, WriteAudioFileError
 
 
-class EnglishAudioFileWriter(AudioFileWriter):
+class AudioFileWriter(BinaryWriter):
     def __init__(self) -> None:
         pass
 

--- a/src/infrastructure/repositories/__init__.py
+++ b/src/infrastructure/repositories/__init__.py
@@ -1,3 +1,3 @@
-from .english_audio_repository import EnglishAudioRepository
+from .general_audio_repository import GeneralAudioRepository
 
-__all__ = ['EnglishAudioRepository']
+__all__ = ['GeneralAudioRepository']

--- a/src/infrastructure/repositories/general_audio_repository.py
+++ b/src/infrastructure/repositories/general_audio_repository.py
@@ -4,7 +4,7 @@ from src.application.interfaces import AudioRepository
 from src.exceptions import FetchAudioStreamError
 
 
-class EnglishAudioRepository(AudioRepository):
+class GeneralAudioRepository(AudioRepository):
     def __init__(self) -> None:
         pass
 

--- a/tests/application/use_cases/test_download_audio_use_case.py
+++ b/tests/application/use_cases/test_download_audio_use_case.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock
 import pytest
 import requests
 
-from src.application.interfaces import AudioFileWriter, AudioRepository
+from src.application.interfaces import AudioRepository, BinaryWriter
 from src.application.use_cases import DownloadAudioUseCase
 
 
@@ -13,15 +13,15 @@ def mock_audio_repository(mocker: Mock) -> Mock:
 
 
 @pytest.fixture
-def mock_audio_file_writer(mocker: Mock) -> Mock:
-    return mocker.Mock(spec=AudioFileWriter)
+def mock_binary_writer(mocker: Mock) -> Mock:
+    return mocker.Mock(spec=BinaryWriter)
 
 
 def test_call_audio_repository(
-    mock_audio_repository: Mock, mock_audio_file_writer: Mock
+    mock_audio_repository: Mock, mock_binary_writer: Mock
 ) -> None:
     download_audio_use_case = DownloadAudioUseCase(
-        mock_audio_repository, mock_audio_file_writer
+        mock_audio_repository, mock_binary_writer
     )
     audio_repository_url = 'https://example.com/audio.mp3'
     download_audio_use_case._get_audio_stream(audio_repository_url)
@@ -30,25 +30,23 @@ def test_call_audio_repository(
     )
 
 
-def test_call_audio_file_writer(
-    mocker: Mock, mock_audio_repository: Mock, mock_audio_file_writer: Mock
+def test_call_binary_writer(
+    mocker: Mock, mock_audio_repository: Mock, mock_binary_writer: Mock
 ) -> None:
     download_audio_use_case = DownloadAudioUseCase(
-        mock_audio_repository, mock_audio_file_writer
+        mock_audio_repository, mock_binary_writer
     )
     audio_file_path = 'path/to/audio.mp3'
     response = mocker.Mock(spec=requests.Response)
     download_audio_use_case._write_audio_file(response, audio_file_path)
-    mock_audio_file_writer.write.assert_called_once_with(
-        response, audio_file_path
-    )
+    mock_binary_writer.write.assert_called_once_with(response, audio_file_path)
 
 
 def test_execute(
-    mocker: Mock, mock_audio_repository: Mock, mock_audio_file_writer: Mock
+    mocker: Mock, mock_audio_repository: Mock, mock_binary_writer: Mock
 ) -> None:
     download_audio_use_case = DownloadAudioUseCase(
-        mock_audio_repository, mock_audio_file_writer
+        mock_audio_repository, mock_binary_writer
     )
     audio_stream = mocker.Mock(spec=requests.Response)
     mock_get_audio_stream = mocker.patch.object(


### PR DESCRIPTION
This pull request includes several changes to rename classes and update references throughout the codebase to reflect these new names. The main focus is on renaming `AudioFileWriter` to `BinaryWriter` and `EnglishAudioRepository` to `GeneralAudioRepository`.

Class and file renaming:

* Renamed `AudioFileWriter` to `BinaryWriter` in `src/application/interfaces/binary_writer.py`.
* Renamed `EnglishAudioRepository` to `GeneralAudioRepository` in `src/infrastructure/repositories/general_audio_repository.py`.

Updates to imports and references:

* Updated imports and references in `main.py` to use `BinaryWriter` and `GeneralAudioRepository` [[1]](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1L4-R5) [[2]](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1L18-R19).
* Updated imports and references in `src/application/use_cases/download_audio_use_case.py` to use `BinaryWriter` [[1]](diffhunk://#diff-82fc1ae91f311ca002a48d09f671cd3b83f0d4df80332797a1aee21b1afe8713L3-R14) [[2]](diffhunk://#diff-82fc1ae91f311ca002a48d09f671cd3b83f0d4df80332797a1aee21b1afe8713L32-R32).
* Updated imports and references in `tests/application/use_cases/test_download_audio_use_case.py` to use `BinaryWriter` [[1]](diffhunk://#diff-51c47c69104028fa5ae5a03c8d9f5c43425061e5fcf581c207f99c559c950749L6-R6) [[2]](diffhunk://#diff-51c47c69104028fa5ae5a03c8d9f5c43425061e5fcf581c207f99c559c950749L16-R24) [[3]](diffhunk://#diff-51c47c69104028fa5ae5a03c8d9f5c43425061e5fcf581c207f99c559c950749L33-R49).

Documentation updates:

* Updated `docs/pyaudio.drawio` to reflect the renaming of `AudioFileWriter` to `BinaryWriter` and `EnglishAudioFileWriter` to `AudioFileWriter` [[1]](diffhunk://#diff-cca459eabc3d22b2dc0c4b8bd144419781020907ad18c0b95224838a8842a95bL55-R55) [[2]](diffhunk://#diff-cca459eabc3d22b2dc0c4b8bd144419781020907ad18c0b95224838a8842a95bL64-R64).